### PR TITLE
[Automation] Bump EDOT versions

### DIFF
--- a/docs/docset.yml
+++ b/docs/docset.yml
@@ -33,7 +33,7 @@ subs:
   edot-dotnet-version: 1.0.2
   edot-ios-version: 1.2.1
   edot-java-version: 1.4.1
-  edot-nodejs-version: 1.0.0
+  edot-nodejs-version: opamp-client-node-v0.1.0
   edot-php-version: 1.0.0
   edot-python-version: 1.2.0
 

--- a/docs/docset.yml
+++ b/docs/docset.yml
@@ -31,7 +31,7 @@ subs:
   edot-collector-version: 9.0.1
   edot-android-version: 1.0.0
   edot-dotnet-version: 1.0.2
-  edot-ios-version:  1.2.0
+  edot-ios-version: 1.2.1
   edot-java-version: 1.4.1
   edot-nodejs-version: 1.0.0
   edot-php-version: 1.0.0

--- a/docs/docset.yml
+++ b/docs/docset.yml
@@ -30,7 +30,7 @@ subs:
   edot-stack-version: 9.0.0
   edot-collector-version: 9.0.0
   edot-android-version: 1.0.0
-  edot-dotnet-version: 1.0.1
+  edot-dotnet-version: 1.0.2
   edot-ios-version:  1.2.0
   edot-java-version: 1.4.1
   edot-nodejs-version: 1.0.1

--- a/docs/docset.yml
+++ b/docs/docset.yml
@@ -34,7 +34,7 @@ subs:
   edot-ios-version:  1.2.0
   edot-java-version: 1.4.1
   edot-nodejs-version: 1.0.1
-  edot-php-version: 1.0.1
+  edot-php-version: 1.0.0
   edot-python-version: 1.2.1
 
   # Substitutions

--- a/docs/docset.yml
+++ b/docs/docset.yml
@@ -35,7 +35,7 @@ subs:
   edot-java-version: 1.4.1
   edot-nodejs-version: 1.0.0
   edot-php-version: 1.0.0
-  edot-python-version: 1.2.1
+  edot-python-version: 1.2.0
 
   # Substitutions
 

--- a/docs/docset.yml
+++ b/docs/docset.yml
@@ -33,7 +33,7 @@ subs:
   edot-dotnet-version: 1.0.2
   edot-ios-version:  1.2.0
   edot-java-version: 1.4.1
-  edot-nodejs-version: 1.0.1
+  edot-nodejs-version: 1.0.0
   edot-php-version: 1.0.0
   edot-python-version: 1.2.1
 

--- a/docs/docset.yml
+++ b/docs/docset.yml
@@ -28,7 +28,7 @@ subs:
   # Versions metadata
 
   edot-stack-version: 9.0.0
-  edot-collector-version: 9.0.1
+  edot-collector-version: 9.0.2
   edot-android-version: 1.0.0
   edot-dotnet-version: 1.0.2
   edot-ios-version: 1.2.1

--- a/docs/docset.yml
+++ b/docs/docset.yml
@@ -32,7 +32,7 @@ subs:
   edot-android-version: 1.0.0
   edot-dotnet-version: 1.0.1
   edot-ios-version:  1.2.0
-  edot-java-version: 1.4.0
+  edot-java-version: 1.4.1
   edot-nodejs-version: 1.0.1
   edot-php-version: 1.0.1
   edot-python-version: 1.2.1

--- a/docs/docset.yml
+++ b/docs/docset.yml
@@ -29,7 +29,7 @@ subs:
 
   edot-stack-version: 9.0.0
   edot-collector-version: 9.0.0
-  edot-android-version: 1.0.1
+  edot-android-version: 1.0.0
   edot-dotnet-version: 1.0.1
   edot-ios-version:  1.2.0
   edot-java-version: 1.4.0

--- a/docs/docset.yml
+++ b/docs/docset.yml
@@ -28,7 +28,7 @@ subs:
   # Versions metadata
 
   edot-stack-version: 9.0.0
-  edot-collector-version: 9.0.0
+  edot-collector-version: 9.0.1
   edot-android-version: 1.0.0
   edot-dotnet-version: 1.0.2
   edot-ios-version:  1.2.0


### PR DESCRIPTION



<Actions>
    <action id="f2c76afb11549aae793cf7d3de1b090ddecc60849fce58a514d0821a80847618">
        <h3>Bump release versions in the docs/docset.yml</h3>
        <details id="583d46052c7f8997d9c4c542c003d1ec597930fe3aecc9ca451c97542a159183">
            <summary>Update docs/docset.yml edot-node 1.0.0</summary>
            <p>1 file(s) updated with &#34;$1: 1.0.0&#34;:&#xA;&#x9;* docs/docset.yml&#xA;</p>
            <details>
                <summary>1.0.0</summary>
                <pre>&#xA;Release published on the 2025-04-01 21:06:35 +0000 UTC at the url https://github.com/elastic/elastic-otel-node/releases/tag/v1.0.0&#xA;&#xA;## Changelog&#xA;&#xA;- BREAKING CHANGE: Change the default behavior of logging framework&#xA;  instrumentations (for Bunyan, Pino, and Winston), to *not* do &#34;log sending&#34;&#xA;  by default. &#34;Log sending&#34; is the feature name of&#xA;  [`@opentelemetry/instrumentation-bunyan`](https://github.com/open-telemetry/opentelemetry-js-contrib/blob/main/plugins/node/opentelemetry-instrumentation-bunyan/README.md#log-sending),&#xA;  [`@opentelemetry/instrumentation-pino`](https://github.com/open-telemetry/opentelemetry-js-contrib/blob/main/plugins/node/opentelemetry-instrumentation-pino/README.md#log-sending), and&#xA;  [`@opentelemetry/instrumentation-winston`](https://github.com/open-telemetry/opentelemetry-js-contrib/blob/main/plugins/node/opentelemetry-instrumentation-winston/README.md#log-sending)&#xA;  to send log records directly to the configured OTLP collector. The new&#xA;  default behavior effectively sets the default config for these&#xA;  instrumentations to `{disableLogSending: true}`.&#xA;&#xA;  This default behavior differs from the current default in OpenTelemetry JS.&#xA;  [OpenTelemetry **Java** instrumentation docs](https://opentelemetry.io/docs/languages/java/instrumentation/#log-instrumentation)&#xA;  provide an argument for why log sending (or &#34;Direct to collector&#34;) should be&#xA;  opt-in. A common workflow for applications is to log to file or stdout and&#xA;  have some external process collect those logs. In those cases, if the&#xA;  OpenTelemetry SDK was *also* sending logs directly, then the telemetry&#xA;  backend would very likely have duplicate logs.&#xA;&#xA;  This is controlled by the `ELASTIC_OTEL_ENABLE_LOG_SENDING` environment variable.&#xA;  To enable log-sending by default, set `ELASTIC_OTEL_ENABLE_LOG_SENDING=true`.&#xA;  (https://github.com/elastic/elastic-otel-node/issues/680)&#xA;&#xA;- BREAKING CHANGE: Set default value of `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE` to delta.&#xA;  This change is done to follow the recommendations specified in the [EDOT docs](https://github.com/elastic/opentelemetry/pull/63).&#xA;  (https://github.com/elastic/elastic-otel-node/pull/670)&#xA;&#xA;- feat: Default to stable semantic conventions for HTTP instrumentation.&#xA;  (https://github.com/elastic/elastic-otel-node/pull/669)&#xA;&#xA;- Upgrade upstream OTel dependencies to SDK 2.0. This should be non-breaking&#xA;  for users of `node --import @elastic/opentelemetry-node my-app.js` to start&#xA;  EDOT Node.js for their application.&#xA;  (https://github.com/elastic/elastic-otel-node/pull/663)&#xA;&#xA;- BREAKING CHANGE: Remove support for passing in a *function* for a particular&#xA;  instrumentation to the `getInstrumentations()` utility. It wasn&#39;t adding any&#xA;  value.&#xA;&#xA;- chore: Use `peerDependencies` for `@opentelemetry/api` dep, and cap it to a&#xA;  known-supported maximum version, according to [OTel JS guidance for&#xA;  implementors](https://github.com/open-telemetry/opentelemetry-js/issues/4832)&#xA;  (https://github.com/elastic/elastic-otel-node/issues/606)&#xA;&#xA;- BREAKING CHANGE: Remove the `@elastic/opentelemetry-node/sdk` entry-point for the 1.0.0 release.&#xA;  This will be brought back in a minor release. It is being removed so that the&#xA;  exported API can be re-worked to be more supportable.&#xA;&#xA;- BREAKING CHANGE: Temporarily remove the &#39;gcp&#39; resource detector, due to an&#xA;  [issue](https://github.com/open-telemetry/opentelemetry-js-contrib/issues/2320)&#xA;  that results in misleading tracing data from the resource detector appearing&#xA;  to be from the application.&#xA;  (https://github.com/elastic/elastic-otel-node/pull/703)&#xA;&#xA;&#xA;---&#xA;&#xA;[README](https://github.com/elastic/elastic-otel-node/tree/main/packages/opentelemetry-node#readme) | [Full Changelog](https://github.com/elastic/elastic-otel-node/blob/main/packages/opentelemetry-node/CHANGELOG.md)&#xA;</pre>
            </details>
            <details>
                <summary>opamp-client-node-v0.1.0</summary>
                <pre>&#xA;Release published on the 2025-06-05 19:52:24 +0000 UTC at the url https://github.com/elastic/elastic-otel-node/releases/tag/opamp-client-node-v0.1.0&#xA;&#xA;## Changelog&#xA;&#xA;Initial release.&#xA;&#xA;---&#xA;&#xA;[README](https://github.com/elastic/elastic-otel-node/tree/main/packages/opamp-client-node#readme) | [Full Changelog](https://github.com/elastic/elastic-otel-node/blob/main/packages/opamp-client-node/CHANGELOG.md)&#xA;</pre>
            </details>
        </details>
        <details id="614a109c2a9d8554c05e9620e3ffc3a445fa8906f41d29f963fe6c60a1e264e6">
            <summary>Update docs/docset.yml edot-python 1.2.0</summary>
            <p>1 file(s) updated with &#34;$1: 1.2.0&#34;:&#xA;&#x9;* docs/docset.yml&#xA;</p>
            <details>
                <summary>1.2.0</summary>
                <pre>&#xA;Release published on the 2025-05-26 12:33:01 +0000 UTC at the url https://github.com/elastic/elastic-otel-python/releases/tag/v1.2.0&#xA;&#xA;## What&#39;s Changed&#xD;&#xA;&#xD;&#xA;- Bump to OTel 1.33.1: logs OTLP serialization improvements, stable `code` attributes used in logs (#307)&#xD;&#xA;&#xD;&#xA;  Upstream changes:&#xD;&#xA;  * https://github.com/open-telemetry/opentelemetry-python/discussions/4574&#xD;&#xA;  * https://github.com/open-telemetry/opentelemetry-python-contrib/discussions/3487&#xD;&#xA;- Bump openai instrumentation to 1.1.1 in docker image (#308)&#xD;&#xA;&#xD;&#xA;## New Contributors&#xD;&#xA;* @theletterf made their first contribution in https://github.com/elastic/elastic-otel-python/pull/305&#xD;&#xA;&#xD;&#xA;**Full Changelog**: https://github.com/elastic/elastic-otel-python/compare/v1.1.0...v1.2.0</pre>
            </details>
        </details>
        <details id="6f19f3c7ac0f343686ae30c63a8218892d6f03962c509d3313be0fdae3dee89d">
            <summary>Update docs/docset.yml edot-android 1.2.1</summary>
            <p>1 file(s) updated with &#34;$1: 1.2.1&#34;:&#xA;&#x9;* docs/docset.yml&#xA;</p>
            <details>
                <summary>1.2.1</summary>
                <pre>&#xA;Release published on the 2025-02-21 18:45:50 +0000 UTC at the url https://github.com/elastic/apm-agent-ios/releases/tag/v1.2.1&#xA;&#xA;## What&#39;s Changed&#xD;&#xA;* CrashExporter doesn&#39;t respect connection type setting by @bryce-b in https://github.com/elastic/apm-agent-ios/pull/249&#xD;&#xA;* Update OpenTelemetry-Swift to version 1.13.0&#xD;&#xA;&#xD;&#xA;**Full Changelog**: https://github.com/elastic/apm-agent-ios/compare/v1.2.0...v1.2.1</pre>
            </details>
        </details>
        <details id="871abf97a2be8f3694240e667098fee1524cce60c308d189e5bc4a95c607a572">
            <summary>Update docs/docset.yml edot-collector 9.0.1</summary>
            <p>1 file(s) updated with &#34;$1: 9.0.1&#34;:&#xA;&#x9;* docs/docset.yml&#xA;</p>
            <details>
                <summary>9.0.1</summary>
                <pre>&#xA;Release published on the 2025-05-06 16:11:31 +0000 UTC at the url https://github.com/elastic/elastic-agent/releases/tag/v9.0.1&#xA;&#xA;Downloads: https://elastic.co/downloads/elastic-agent&#xA;Release notes: https://www.elastic.co/docs/release-notes/fleet#fleet-elastic-agent-9.0-release-notes&#xA;</pre>
            </details>
            <details>
                <summary>9.0.2</summary>
                <pre>&#xA;Release published on the 2025-06-03 14:38:29 +0000 UTC at the url https://github.com/elastic/elastic-agent/releases/tag/v9.0.2&#xA;&#xA;Downloads: https://elastic.co/downloads/elastic-agent&#xA;Release notes: https://www.elastic.co/docs/release-notes/fleet#fleet-elastic-agent-9.0.2-release-notes&#xA;</pre>
            </details>
        </details>
        <details id="95c972bba4b09608c611c65e9479b20b025b630345593be4242a688a55bbf38e">
            <summary>Update docs/docset.yml edot-android 1.0.0</summary>
            <p>1 file(s) updated with &#34;$1: 1.0.0&#34;:&#xA;&#x9;* docs/docset.yml&#xA;</p>
            <details>
                <summary>1.0.0</summary>
                <pre>&#xA;Release published on the 2025-04-02 13:29:42 +0000 UTC at the url https://github.com/elastic/apm-agent-android/releases/tag/v1.0.0&#xA;&#xA;[Release Notes for 1.0.0](https://www.elastic.co/docs/release-notes/apm/agents/android#elastic-apm-android-agent-100-release-notes)</pre>
            </details>
        </details>
        <details id="af6d4913280bf03a0e447b55a1933432b90ffe21547cecc7ab528b0d5447a562">
            <summary>Update docs/docset.yml edot-java 1.4.1</summary>
            <p>1 file(s) updated with &#34;$1: 1.4.1&#34;:&#xA;&#x9;* docs/docset.yml&#xA;</p>
            <details>
                <summary>1.4.1</summary>
                <pre>&#xA;Release published on the 2025-04-16 10:29:39 +0000 UTC at the url https://github.com/elastic/elastic-otel-java/releases/tag/v1.4.1&#xA;&#xA;* Fix `otel.exporter.otlp.metrics.temporality.preference` config option having no effect. - #610&#xA;&#xA;This release is based on the following upstream versions:&#xA;&#xA;* opentelemetry-javaagent: [2.15.0](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v2.15.0)&#xA;* opentelemetry-sdk: [1.49.0](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.49.0)&#xA;* opentelemetry-semconv: [1.32.0](https://github.com/open-telemetry/semantic-conventions-java/releases/tag/v1.32.0)&#xA;* opentelemetry-java-contrib: [1.45.0](https://github.com/open-telemetry/opentelemetry-java-contrib/releases/tag/v1.45.0)</pre>
            </details>
        </details>
        <details id="b02dc1557eb39ee7d1baf1e4a3cc4bcdc62425f27ec125c2df6508d4d066d6fd">
            <summary>Update docs/docset.yml edot-php 1.0.0</summary>
            <p>1 file(s) updated with &#34;$1: 1.0.0&#34;:&#xA;&#x9;* docs/docset.yml&#xA;</p>
            <details>
                <summary>1.0.0</summary>
                <pre>&#xA;Release published on the 2025-04-02 10:21:47 +0000 UTC at the url https://github.com/elastic/elastic-otel-php/releases/tag/v1.0.0&#xA;&#xA;&#xA;### What&#39;s new&#xA;&#xA;- OTLP protobuf built-in native serialization (PR [#198](https://github.com/elastic/elastic-otel-php/pull/198))&#xA;&#xA;### Technical news&#xA;- Move EDOT PHP documentation to elastic/opentelemetry (PR [#197](https://github.com/elastic/elastic-otel-php/pull/197))&#xA;&#xA;Full changelog: [v0.4.0...v1.0.0](https://github.com/elastic/elastic-otel-php/compare/v0.4.0...v1.0.0)</pre>
            </details>
        </details>
        <details id="b9e9ebd34b6cc5221a6761f7611d5119e3e054677b0c3ffb1a39ab07b11361af">
            <summary>Update docs/docset.yml edot-dotnet 1.0.2</summary>
            <p>1 file(s) updated with &#34;$1: 1.0.2&#34;:&#xA;&#x9;* docs/docset.yml&#xA;</p>
            <details>
                <summary>1.0.2</summary>
                <pre>&#xA;Release published on the 2025-04-11 11:34:13 +0000 UTC at the url https://github.com/elastic/elastic-otel-dotnet/releases/tag/1.0.2&#xA;&#xA;## What&#39;s Changed&#xD;&#xA;&#xD;&#xA;### Enhancements&#xD;&#xA;&#xD;&#xA;* Log after adding AspNetCore trace instrumentation by @stevejgordon in https://github.com/elastic/elastic-otel-dotnet/pull/262&#xD;&#xA;&#xD;&#xA;Improves the trace logging for diagnostic and support purposes.&#xD;&#xA;&#xD;&#xA;### Behaviour change&#xD;&#xA;&#xD;&#xA;* No longer default to IncludeScopes by @stevejgordon in https://github.com/elastic/elastic-otel-dotnet/pull/265&#xD;&#xA;&#xD;&#xA;The upstream SDK isn&#39;t spec-compliant regarding not exporting duplicate attributes. As such, when using `IncludeScopes` in ASP.NET Core, log entries often include a duplicated `RequestId` attribute. The Elasticsearch exporter component of the collector expects the data to comply with the spec and, for performance reasons, doesn&#39;t attempt to de-duplicate, resulting in export errors for the log record. EDOT .NET no longer enables `IncludeScopes` by default as a partial workaround. This will be re-enabled in a future release, once the risk of data loss is resolved upstream.&#xD;&#xA;&#xD;&#xA;References:&#xD;&#xA;- https://github.com/open-telemetry/opentelemetry-dotnet/issues/4324&#xD;&#xA;- https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/39304&#xD;&#xA;&#xD;&#xA;**Full Changelog**: https://github.com/elastic/elastic-otel-dotnet/compare/1.0.1...1.0.2</pre>
            </details>
        </details>
    </action>
</Actions>

---

<table>
  <tr>
    <td width="77">
      <img src="https://www.updatecli.io/images/updatecli.png" alt="Updatecli logo" width="50" height="50">
    </td>
    <td>
      <p>
        Created automatically by <a href="https://www.updatecli.io/">Updatecli</a>
      </p>
      <details><summary>Options:</summary>
        <br />
        <p>Most of Updatecli configuration is done via <a href="https://www.updatecli.io/docs/prologue/quick-start/">its manifest(s)</a>.</p>
        <ul>
          <li>If you close this pull request, Updatecli will automatically reopen it, the next time it runs.</li>
          <li>If you close this pull request and delete the base branch, Updatecli will automatically recreate it, erasing all previous commits made.</li>
        </ul>
        <p>
          Feel free to report any issues at <a href="https://github.com/updatecli/updatecli/issues">github.com/updatecli/updatecli</a>.<br />
          If you find this tool useful, do not hesitate to star <a href="https://github.com/updatecli/updatecli/stargazers">our GitHub repository</a> as a sign of appreciation, and/or to tell us directly on our <a href="https://matrix.to/#/#Updatecli_community:gitter.im">chat</a>!
        </p>
      </details>
    </td>
  </tr>
</table>

