### PR TITLE
[Automation] Bump EDOT versions

### DIFF
--- a/docs/docset.yml
+++ b/docs/docset.yml
@@ -33,7 +33,7 @@ subs:
   edot-dotnet-version: 1.0.2
   edot-ios-version: 1.2.1
   edot-java-version: 1.4.1
-  edot-nodejs-version: 1.0.0
+  edot-nodejs-version: opamp-client-node-v0.1.0
   edot-php-version: 1.0.0
   edot-python-version: 1.2.0
 

--- a/docs/docset.yml
+++ b/docs/docset.yml
@@ -31,7 +31,7 @@ subs:
   edot-collector-version: 9.0.1
   edot-android-version: 1.0.0
   edot-dotnet-version: 1.0.2
-  edot-ios-version:  1.2.0
+  edot-ios-version: 1.2.1
   edot-java-version: 1.4.1
   edot-nodejs-version: 1.0.0
   edot-php-version: 1.0.0

--- a/docs/docset.yml
+++ b/docs/docset.yml
@@ -30,7 +30,7 @@ subs:
   edot-stack-version: 9.0.0
   edot-collector-version: 9.0.0
   edot-android-version: 1.0.0
-  edot-dotnet-version: 1.0.1
+  edot-dotnet-version: 1.0.2
   edot-ios-version:  1.2.0
   edot-java-version: 1.4.1
   edot-nodejs-version: 1.0.1

--- a/docs/docset.yml
+++ b/docs/docset.yml
@@ -34,7 +34,7 @@ subs:
   edot-ios-version:  1.2.0
   edot-java-version: 1.4.1
   edot-nodejs-version: 1.0.1
-  edot-php-version: 1.0.1
+  edot-php-version: 1.0.0
   edot-python-version: 1.2.1
 
   # Substitutions

--- a/docs/docset.yml
+++ b/docs/docset.yml
@@ -35,7 +35,7 @@ subs:
   edot-java-version: 1.4.1
   edot-nodejs-version: 1.0.0
   edot-php-version: 1.0.0
-  edot-python-version: 1.2.1
+  edot-python-version: 1.2.0
 
   # Substitutions
 

--- a/docs/docset.yml
+++ b/docs/docset.yml
@@ -33,7 +33,7 @@ subs:
   edot-dotnet-version: 1.0.2
   edot-ios-version:  1.2.0
   edot-java-version: 1.4.1
-  edot-nodejs-version: 1.0.1
+  edot-nodejs-version: 1.0.0
   edot-php-version: 1.0.0
   edot-python-version: 1.2.1
 

--- a/docs/docset.yml
+++ b/docs/docset.yml
@@ -28,7 +28,7 @@ subs:
   # Versions metadata
 
   edot-stack-version: 9.0.0
-  edot-collector-version: 9.0.1
+  edot-collector-version: 9.0.2
   edot-android-version: 1.0.0
   edot-dotnet-version: 1.0.2
   edot-ios-version: 1.2.1

--- a/docs/docset.yml
+++ b/docs/docset.yml
@@ -33,7 +33,7 @@ subs:
   edot-dotnet-version: 1.0.2
   edot-ios-version: 1.2.1
   edot-java-version: 1.4.1
-  edot-nodejs-version: opamp-client-node-v0.1.0
+  edot-nodejs-version: 1.0.0
   edot-php-version: 1.0.0
   edot-python-version: 1.2.0
 

--- a/docs/docset.yml
+++ b/docs/docset.yml
@@ -32,7 +32,7 @@ subs:
   edot-android-version: 1.0.0
   edot-dotnet-version: 1.0.1
   edot-ios-version:  1.2.0
-  edot-java-version: 1.4.0
+  edot-java-version: 1.4.1
   edot-nodejs-version: 1.0.1
   edot-php-version: 1.0.1
   edot-python-version: 1.2.1

--- a/docs/docset.yml
+++ b/docs/docset.yml
@@ -29,7 +29,7 @@ subs:
 
   edot-stack-version: 9.0.0
   edot-collector-version: 9.0.0
-  edot-android-version: 1.0.1
+  edot-android-version: 1.0.0
   edot-dotnet-version: 1.0.1
   edot-ios-version:  1.2.0
   edot-java-version: 1.4.0

--- a/docs/docset.yml
+++ b/docs/docset.yml
@@ -28,7 +28,7 @@ subs:
   # Versions metadata
 
   edot-stack-version: 9.0.0
-  edot-collector-version: 9.0.0
+  edot-collector-version: 9.0.1
   edot-android-version: 1.0.0
   edot-dotnet-version: 1.0.2
   edot-ios-version:  1.2.0


### PR DESCRIPTION



<Actions>
    <action id="f2c76afb11549aae793cf7d3de1b090ddecc60849fce58a514d0821a80847618">
        <h3>Bump release versions in the docs/docset.yml</h3>
        <details id="583d46052c7f8997d9c4c542c003d1ec597930fe3aecc9ca451c97542a159183">
            <summary>Update docs/docset.yml edot-node 1.0.0</summary>
            <p>1 file(s) updated with &#34;$1: 1.0.0&#34;:&#xA;&#x9;* docs/docset.yml&#xA;</p>
            <details>
                <summary>1.0.0</summary>
                <pre>&#xA;Release published on the 2025-04-01 21:06:35 +0000 UTC at the url https://github.com/elastic/elastic-otel-node/releases/tag/v1.0.0&#xA;&#xA;## Changelog&#xA;&#xA;- BREAKING CHANGE: Change the default behavior of logging framework&#xA;  instrumentations (for Bunyan, Pino, and Winston), to *not* do &#34;log sending&#34;&#xA;  by default. &#34;Log sending&#34; is the feature name of&#xA;  [`@opentelemetry/instrumentation-bunyan`](https://github.com/open-telemetry/opentelemetry-js-contrib/blob/main/plugins/node/opentelemetry-instrumentation-bunyan/README.md#log-sending),&#xA;  [`@opentelemetry/instrumentation-pino`](https://github.com/open-telemetry/opentelemetry-js-contrib/blob/main/plugins/node/opentelemetry-instrumentation-pino/README.md#log-sending), and&#xA;  [`@opentelemetry/instrumentation-winston`](https://github.com/open-telemetry/opentelemetry-js-contrib/blob/main/plugins/node/opentelemetry-instrumentation-winston/README.md#log-sending)&#xA;  to send log records directly to the configured OTLP collector. The new&#xA;  default behavior effectively sets the default config for these&#xA;  instrumentations to `{disableLogSending: true}`.&#xA;&#xA;  This default behavior differs from the current default in OpenTelemetry JS.&#xA;  [OpenTelemetry **Java** instrumentation docs](https://opentelemetry.io/docs/languages/java/instrumentation/#log-instrumentation)&#xA;  provide an argument for why log sending (or &#34;Direct to collector&#34;) should be&#xA;  opt-in. A common workflow for applications is to log to file or stdout and&#xA;  have some external process collect those logs. In those cases, if the&#xA;  OpenTelemetry SDK was *also* sending logs directly, then the telemetry&#xA;  backend would very likely have duplicate logs.&#xA;&#xA;  This is controlled by the `ELASTIC_OTEL_ENABLE_LOG_SENDING` environment variable.&#xA;  To enable log-sending by default, set `ELASTIC_OTEL_ENABLE_LOG_SENDING=true`.&#xA;  (https://github.com/elastic/elastic-otel-node/issues/680)&#xA;&#xA;- BREAKING CHANGE: Set default value of `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE` to delta.&#xA;  This change is done to follow the recommendations specified in the [EDOT docs](https://github.com/elastic/opentelemetry/pull/63).&#xA;  (https://github.com/elastic/elastic-otel-node/pull/670)&#xA;&#xA;- feat: Default to stable semantic conventions for HTTP instrumentation.&#xA;  (https://github.com/elastic/elastic-otel-node/pull/669)&#xA;&#xA;- Upgrade upstream OTel dependencies to SDK 2.0. This should be non-breaking&#xA;  for users of `node --import @elastic/opentelemetry-node my-app.js` to start&#xA;  EDOT Node.js for their application.&#xA;  (https://github.com/elastic/elastic-otel-node/pull/663)&#xA;&#xA;- BREAKING CHANGE: Remove support for passing in a *function* for a particular&#xA;  instrumentation to the `getInstrumentations()` utility. It wasn&#39;t adding any&#xA;  value.&#xA;&#xA;- chore: Use `peerDependencies` for `@opentelemetry/api` dep, and cap it to a&#xA;  known-supported maximum version, according to [OTel JS guidance for&#xA;  implementors](https://github.com/open-telemetry/opentelemetry-js/issues/4832)&#xA;  (https://github.com/elastic/elastic-otel-node/issues/606)&#xA;&#xA;- BREAKING CHANGE: Remove the `@elastic/opentelemetry-node/sdk` entry-point for the 1.0.0 release.&#xA;  This will be brought back in a minor release. It is being removed so that the&#xA;  exported API can be re-worked to be more supportable.&#xA;&#xA;- BREAKING CHANGE: Temporarily remove the &#39;gcp&#39; resource detector, due to an&#xA;  [issue](https://github.com/open-telemetry/opentelemetry-js-contrib/issues/2320)&#xA;  that results in misleading tracing data from the resource detector appearing&#xA;  to be from the application.&#xA;  (https://github.com/elastic/elastic-otel-node/pull/703)&#xA;&#xA;&#xA;---&#xA;&#xA;[README](https://github.com/elastic/elastic-otel-node/tree/main/packages/opentelemetry-node#readme) | [Full Changelog](https://github.com/elastic/elastic-otel-node/blob/main/packages/opentelemetry-node/CHANGELOG.md)&#xA;</pre>
            </details>
        </details>
    </action>
</Actions>

---

<table>
  <tr>
    <td width="77">
      <img src="https://www.updatecli.io/images/updatecli.png" alt="Updatecli logo" width="50" height="50">
    </td>
    <td>
      <p>
        Created automatically by <a href="https://www.updatecli.io/">Updatecli</a>
      </p>
      <details><summary>Options:</summary>
        <br />
        <p>Most of Updatecli configuration is done via <a href="https://www.updatecli.io/docs/prologue/quick-start/">its manifest(s)</a>.</p>
        <ul>
          <li>If you close this pull request, Updatecli will automatically reopen it, the next time it runs.</li>
          <li>If you close this pull request and delete the base branch, Updatecli will automatically recreate it, erasing all previous commits made.</li>
        </ul>
        <p>
          Feel free to report any issues at <a href="https://github.com/updatecli/updatecli/issues">github.com/updatecli/updatecli</a>.<br />
          If you find this tool useful, do not hesitate to star <a href="https://github.com/updatecli/updatecli/stargazers">our GitHub repository</a> as a sign of appreciation, and/or to tell us directly on our <a href="https://matrix.to/#/#Updatecli_community:gitter.im">chat</a>!
        </p>
      </details>
    </td>
  </tr>
</table>

